### PR TITLE
CI/CD Pipeline is broken: fix code checker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this plugin is 7.27.1 (9th of nov. 2021).
 
+## [Unreleased]
+
+- fix(ci): moodle code checker errors (#19424)
+
 ## v7.27.1 - 9th nov. 2021
 - Fix "missing ['privacy:metadata']" from @christina-roperto contribution #61
 - Improve the "MathType Moodle Plugins Suite" software development cycle.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace tinymce_tiny_mce_wiris\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Privacy Subsystem for MathType TinyMCE plugin implementing null_provider.
  *

--- a/lib.php
+++ b/lib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 class tinymce_tiny_mce_wiris extends editor_tinymce_plugin {
     protected $buttons = array('tiny_mce_wiris_formulaEditor', 'tiny_mce_wiris_CAS');
 


### PR DESCRIPTION
## Description

The dependency **[moodle-plugin-ci](https://moodlehq.github.io/moodle-plugin-ci/)** that we use to test and analyze our Moodle suit projects code, has been updated to 3.2.3, introducing the following changes:

* PHP_CodeSniffer upgraded to 3.6.2 release (see: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.6.2)
* Report unexpected MOODLE_INTERNAL uses (see: https://github.com/moodlehq/moodle-local_codechecker/pull/169)

This change affects directly to our GitHub Actions workflow, it makes it fail, hence it does not allow us to make new releases of the Moodle suite.

### Implementation

The new release of the _moodle-plugin-ci_ dependency claims that, all PHP files without side-effects must remove unnecessary `MOODLE_INTERNAL` requirements.

```php
defined('MOODLE_INTERNAL') || die();
```

### What is included on this PR:

This PR also includes:
* Remove other warning and errors not related to the `MOODLE_INTERNAL` one.
* Updated CHANGELOG

## Steps to reproduce

* On the Actions tab, find the "Moodle Plugin CI" workflow.
* Use the workflow dispatch option on the KB-19424 branch.
* All moodle code checker verifications should pass without warnings or errors.

[Check GitHub Actions results](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions)

----
[#taskid 19424](https://wiris.kanbanize.com/ctrl_board/2/cards/19487/details/)