### PR TITLE
Add Moodle 4.0 compatibility

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -184,10 +184,18 @@ jobs:
       - name: PHPUnit tests
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit
-      # Run Behat tests on all Moodle branches.
+      # Run Behat tests on latest Moodle branch
       - name: Behat features
-        if: ${{ always() }}
+        if: ${{ matrix.moodle-branch == 'master' }}
         run: moodle-plugin-ci behat --profile default -vvv
+      # Run Behat Legacy test on the rest Moodle branchs
+      - name: Behat legacy features
+        if: ${{ matrix.moodle-branch != 'master' }}
+        run: |
+          docker run -d --rm --name=selenium --net=host --shm-size=2g -v /home/runner/work/moodle-tinymce_tiny_mce_wiris/moodle-tinymce_tiny_mce_wiris/moodle:/home/runner/work/moodle-tinymce_tiny_mce_wiris/moodle-tinymce_tiny_mce_wiris/moodle selenium/standalone-chrome:3
+          nohup php -S localhost:8000 -t /home/runner/work/moodle-tinymce_tiny_mce_wiris/moodle-tinymce_tiny_mce_wiris/moodle > phpd.log 2>&1 &
+          php moodle/admin/tool/behat/cli/run.php --tags=@3.x --profile=chrome --suite=default --auto-rerun=2 --verbose -vvv
+          docker stop selenium
 
       # 5.5. Upload snapshots of errors ( NOT Working )
       # Save videos and screenshots as test artifacts

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -29,7 +29,7 @@ jobs:
     services:
       # The test will be scoped to postgres only.
       postgres:
-        image: postgres:9.6
+        image: postgres:10
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.1','7.4']
-        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE']
+        moodle-branch: ['MOODLE_35_STABLE', 'MOODLE_36_STABLE', 'MOODLE_37_STABLE', 'MOODLE_38_STABLE', 'MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'master']
         database: [pgsql]
         # browser: ['firefox', 'chrome']
         exclude:
@@ -63,24 +63,14 @@ jobs:
             php: '7.1'
           - moodle-branch: 'MOODLE_311_STABLE'
             php: '7.1'
+          - moodle-branch: 'master'
+            php: '7.1'
           - moodle-branch: 'MOODLE_35_STABLE'
             php: '7.4'
           - moodle-branch: 'MOODLE_36_STABLE'
             php: '7.4'
           - moodle-branch: 'MOODLE_37_STABLE'
             php: '7.4'
-          - moodle-branch: 'MOODLE_35_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_36_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_37_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_38_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_39_STABLE'
-            php: '8.0'
-          - moodle-branch: 'MOODLE_310_STABLE'
-            php: '8.0'
 
 
     steps:
@@ -130,7 +120,6 @@ jobs:
           CODECHECKER_IGNORE_PATHS: classes/privacy,ignore,node_modules,integration,render
           PHPUNIT_IGNORE_PATHS: classes/privacy,ignore,node_modules,integration,render
           MOODLE_DOCKER_BEHAT_FAILDUMP: /home/runner/work/moodle-tinymce_tiny_mce_wiris/moodle-tinymce_tiny_mce_wiris/behatfaildumps
-
 
       # 3. Install Filter plugin ( and Quizzes ?)
       - name: Add MathtType filter plugin

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -30,7 +30,7 @@ namespace tinymce_tiny_mce_wiris\privacy;
  * @copyright  WIRIS Europe (Maths for more S.L)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class provider implements \core_privacy\local\metadata\null_provider { 
+class provider implements \core_privacy\local\metadata\null_provider {
 
 
     /**

--- a/tests/behat/edit_formula.feature
+++ b/tests/behat/edit_formula.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @3.x
 Feature: MathType for TinyMCE
   In order to check if formula can be created correctly in tiny
   I need to create a formula in the user profile

--- a/tests/behat/tiny_dataMCECheck.feature
+++ b/tests/behat/tiny_dataMCECheck.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @wiris_bug1
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @wiris_bug1 @3.x
 Feature: Checks if data-mce is set on setContent
 In order to check if the formula remains in the content field
 I need to post
@@ -35,6 +35,6 @@ Check the formula
     And I press accept button in MathType Editor
     And I press "Save and display"
     # Since the formula is inside an iframe, it's not working anymore. 
-    # And I navigate to "Edit settings" in current page administration
+    # And I navigate to "Settings" in current page administration
     # Then I wait until Wirisformula formula exists
     # And a Wirisformula containing "square root of 2" should exist in "Page content" field

--- a/tests/behat/tiny_filterActivityDisabled.feature
+++ b/tests/behat/tiny_filterActivityDisabled.feature
@@ -35,6 +35,5 @@ I need to disable filter at activity page level
     And I navigate to "Filters" in current page administration
     And I turn MathType filter off
     And I press "Save changes"
-    And I follow "Test MathType for Atto on Moodle"
-    And I navigate to "Edit settings" in current page administration
+    And I navigate to "Settings" in current page administration
     Then "MathType" "button" should not exist

--- a/tests/behat/tiny_filterCourseDisabled.feature
+++ b/tests/behat/tiny_filterCourseDisabled.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @3.x
 Feature: Check MathType disabled if filter disabled at course level
 In order to check if MathType will be disabled if filter is disabled at couse level
 I need to disable filter at activity course level

--- a/tests/behat/tiny_fullScreenInsertFormula.feature
+++ b/tests/behat/tiny_fullScreenInsertFormula.feature
@@ -38,5 +38,5 @@ Check the formula
     And I press "Full screen" in full screen mode
     And I press "Save and display"
     Then a Wirisformula containing "square root of 2 pi end root" should exist
-    And I navigate to "Edit settings" in current page administration
+    And I navigate to "Settings" in current page administration
     Then Wirisformula should has width 39 with error of 4 in "Page content" field

--- a/tests/behat/tiny_reopenEditor.feature
+++ b/tests/behat/tiny_reopenEditor.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @3.x
 Feature: Check if editor can be reopened
 In order to check if the MathType editor can be reopened
 I need to open the editor

--- a/tests/behat/tiny_settingMathChemButtonEditorVisibility.feature
+++ b/tests/behat/tiny_settingMathChemButtonEditorVisibility.feature
@@ -1,4 +1,4 @@
-@filter @filter_wiris @filter_wiris_settings @wiris_settings @wiris_mathtype @tinymce @tinymce_tiny_mce_wiris
+@filter @filter_wiris @filter_wiris_settings @wiris_settings @wiris_mathtype @tinymce @tinymce_tiny_mce_wiris @3.x
 Feature: Check the Mathtype and chemtype buttons visibility on text editors
 In order to check the buttons visibility in tinymce editor
 As an admin

--- a/tests/behat/tiny_tinyChemistry.feature
+++ b/tests/behat/tiny_tinyChemistry.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @3.x
 Feature: Use tiny to post with a chemistry formula
 In order to check whether a chemistry formula can be displayed correctly
 I need to post a chemistry formula

--- a/tests/behat/tiny_tinyModal.feature
+++ b/tests/behat/tiny_tinyModal.feature
@@ -1,4 +1,4 @@
-@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype
+@editor @tinymce @tinymce_tiny_mce_wiris @wiris_mathtype @3.x
 Feature: Use tiny to post with modal window
 In order to check if MathType formula can be displayed correctly
 I need to post a MathType formula


### PR DESCRIPTION
## Description 
The main goal of this task is to make all Behat test compatible with Moodle 4.0 branch. Also the tests are compatible with the previous Moodle (3.x)  supported  version.

## How to reproduce:

1. Go to [moodle-tinymce_tiny_mce_wiris github repository Actions section.](https://github.com/wiris/moodle-tinymce_tiny_mce_wiris/actions)
3. Select the `Moodle Plugin CI` workflow.
4. Click on `Run workflow` and select the branch `moodle40`.
5. Click on the `Run workflow` green button.

---

[#taskid 21989](https://wiris.kanbanize.com/ctrl_board/2/cards/21989/details/)