### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/moodle-cd.yml
+++ b/.github/workflows/moodle-cd.yml
@@ -1,0 +1,52 @@
+#
+# Whenever a new tag starting with "v" is pushed, add the tagged version
+# to the Moodle Plugins directory at https://moodle.org/plugins
+#
+# revision: 2021070201
+#
+name: Releasing in the Plugins directory
+on:
+  push:
+    tags:
+      - v*
+defaults:
+  run:
+    shell: bash
+jobs:
+  release-at-moodle-org:
+    runs-on: ubuntu-latest
+    env:
+      PLUGIN: tinymce_tiny_mce_wiris
+      CURL: curl -s
+      ENDPOINT: https://moodle.org/webservice/rest/server.php
+      TOKEN: ${{ secrets.MOODLE_ORG_TOKEN }}
+      FUNCTION: local_plugins_add_version
+    steps:
+      - name: Call the service function
+        id: add-version
+        run: |
+          TAGNAME="${GITHUB_REF##*/}"
+
+          if [[ -z "${TAGNAME}" ]]; then
+            echo "No tag name has been provided!"
+            exit 1
+          fi
+          ZIPURL="https://api.github.com/repos/${{ github.repository }}/zipball/${TAGNAME}"
+          RESPONSE=$(${CURL} ${ENDPOINT} --data-urlencode "wstoken=${TOKEN}" \
+                                         --data-urlencode "wsfunction=${FUNCTION}" \
+                                         --data-urlencode "moodlewsrestformat=json" \
+                                         --data-urlencode "frankenstyle=${PLUGIN}" \
+                                         --data-urlencode "zipurl=${ZIPURL}" \
+                                         --data-urlencode "vcssystem=git" \
+                                         --data-urlencode "vcsrepositoryurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+                                         --data-urlencode "vcstag=${TAGNAME}" \
+                                         --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commits/${TAGNAME}" \
+                                         --data-urlencode "altdownloadurl=${ZIPURL}")
+          echo "::set-output name=response::${RESPONSE}"
+      - name: Evaluate the response
+        id: evaluate-response
+        env:
+          RESPONSE: ${{ steps.add-version.outputs.response }}
+        run: |
+          jq <<< ${RESPONSE}
+          jq --exit-status ".id" <<< ${RESPONSE} > /dev/null

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this plugin is 7.27.1 (9th of nov. 2021).
 
+## [unrelease]
+- ci: add cd workflow
+
 ## v7.29.0 - 20th jun. 2022
 
 - fix(ci): moodle code checker errors (#19424)


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow to automate the release of the `moodle-tinymce_tiny_mce_wiris` plugin.

When a new commit is pushed to the repository with a tag with the prefix ` v ` the GitHub actions workflow will be run.

The plugin will be released using the version details from `version.php` file

## Steps to reproduce

1. Update the `version.php` file with the new version number.
2. Make a commit with the changes.
3. Create a tag using the command `git tag <tag-number>` (the tag number must have the v. prefix e.x: v.7.29.1).
4. Push the changes to the remote repository using the command `git push`.
5. Push the tags to the remote repository using the command `git push --tag`.

The workflow will be run and will release the changes to the Moodle marketplace

---

[#taskid 26096](https://wiris.kanbanize.com/ctrl_board/2/cards/26096/details/)