### PR TITLE
fix: Use branch stable as a failsafe in CI

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -122,9 +122,15 @@ jobs:
           MOODLE_DOCKER_BEHAT_FAILDUMP: /home/runner/work/moodle-tinymce_tiny_mce_wiris/moodle-tinymce_tiny_mce_wiris/behatfaildumps
 
       # 3. Install Filter plugin ( and Quizzes ?)
-      - name: Add MathtType filter plugin
+      - name: Add MathType filter plugin
+        id: install-plugin-filter
+        continue-on-error: true
         run: |
           moodle-plugin-ci add-plugin --branch ${GITHUB_REF##*/} wiris/moodle-filter_wiris
+      - name: Add MathType filter plugin using the stable branch
+        if: steps.install-plugin-filter.outcome != 'success'
+        run: |
+          moodle-plugin-ci add-plugin --branch stable wiris/moodle-filter_wiris
 
       # 4. Install Moodle-plugin-ci
       - name: Install moodle-plugin-ci


### PR DESCRIPTION
# Description

Currently, the CI workflow tries to clone other Moodle plugin repos using the same branch as the one it is running on, and fails if it doesn't find such branch.

With this PR, if such branch is not found on the other projects, it defaults to `stable`, thus easing development on issues that affect only a single repository.

# Validation

If you want, you can validate this change following these steps:

- Clone the project and check out this branch (`KB-25037`).
- Check out a new branch from there, with a brand new name.
- Push that branch to GitHub and let it run the CI workflow.
- The workflow should NOT fail due to a missing branch in our other Moodle plugin repos.